### PR TITLE
Add CodeQL analysis workflow configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,99 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '44 17 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: javascript-typescript
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Final config changes for CodeQL

## Summary
This pull request adds a dedicated CodeQL Advanced workflow to enable automated code scanning for the digital-fabrication-network repository, focusing on JavaScript/TypeScript sources and running on pushes, pull requests, and a weekly schedule.
<!-- Provide a concise description of the changes in this PR. -->

Fixes (not documented) #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->

- [ ] `fix` – Bug fix (non-breaking)
- [ ] `feat` – New feature (non-breaking)
- [ ] `feat!` / `fix!` – Breaking change
- [ ] `chore` – Maintenance, dependency updates, refactoring
- [ ] `docs` – Documentation only
- [x] `ci` – CI/CD configuration changes
- [ ] `test` – Adding or updating tests

## Changes Made

<!-- List the key changes introduced in this PR. -->

- Added .github/workflows/codeql.yml using the CodeQL Advanced template tuned for JavaScript/TypeScript analysis.
​
- Configured triggers for push and pull_request on the main branch, plus a weekly cron run to ensure regular security scanning.
​
- Set up the CodeQL matrix to analyze javascript-typescript with a no-build (build-mode: none) configuration suitable for this repository’s current setup


## Testing

<!-- Describe how you tested your changes. -->

- [ ] Unit tests added / updated
- [x] Manual testing performed (describe below)

**Manual test steps:**

1. Pushed the workflow configuration to the npc-chris-ci-codeql-patch-final branch and opened this pull request to validate that the CodeQL workflow is picked up by GitHub Actions.

2. Verified that the workflow is recognized by the Actions tab and that the configuration passes basic syntax and configuration checks during the initial run.

## Checklist

- [ ] My branch is up to date with `main`/`develop`
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Code has been linted (`npm run lint`)
- [ ] All existing tests pass (`npm test`)
- [x] Relevant documentation has been updated
- [x] No secrets or credentials are committed

## Screenshots (if applicable)

<!-- Add before/after screenshots for UI changes -->
N/A - this change only adds a CI workflow configuration.